### PR TITLE
Add an optional Filtlong step.

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -1,5 +1,17 @@
 includeConfig "luslab-modules/configs/luslab-base.config"
 
+// Global default parameters
+
+params {
+
+    // Fitlong
+    with_filtlong                      = false
+    filtlong_target                    = 4000000000
+
+}
+
+// Manifest
+
 manifest {
     author = 'Michael Mansfield'
     recurseSubmodules = true


### PR DESCRIPTION
The pipeline's command-line interface takes two new parameters: `--with_filtlong` to enable filtering and `filtlong_target` to change the value of filtlong's `--target_bases` option.