### PR TITLE
Correct gitmodule path.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "luslab-nf-modules"]
-    path = modules/luslab-nf-modules/luslab-nf-modules
+    path = modules/luslab-nf-modules
     url = https://github.com/luslab/luslab-nf-modules
     branch = master


### PR DESCRIPTION
Without this correction, the command `git submodule init` errors.